### PR TITLE
Improved Prototype note visibility

### DIFF
--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -30,7 +30,7 @@
 // @import "bootstrap/scss/breadcrumb";
 // @import "bootstrap/scss/pagination";
 @import "bootstrap/scss/badge";
-// @import "bootstrap/scss/alert";
+@import "bootstrap/scss/alert";
 // @import "bootstrap/scss/progress";
 @import "bootstrap/scss/list-group";
 @import "bootstrap/scss/close";

--- a/index.html
+++ b/index.html
@@ -7,6 +7,19 @@ layout: default
     </div>
 </div>
 
+<section class="py-2 bg-yellow-100 border border-end-0 border-start-0 border-warning">
+    <div class="container alert alert-warning mb-0 border-0" role="alert">
+        <div class="d-flex align-items-md-center">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="d-none d-md-block bi bi-exclamation-triangle-fill flex-shrink-0 me-3" viewBox="0 0 16 16" role="img" aria-label="Warning:">
+                <path d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5zm.002 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2z"/>
+              </svg>
+              <p class="fs-m6 mb-0">
+                This dashboard is a work in progress and this is not the final form it will take. There are some parts of the dashboard that are not fully functional and some data may not be accurate, so be aware that the information contained in this version should not be considered in any way definitive.
+              </p>
+        </div>
+    </div>
+</section>
+
 <div class="py-5 py-lg-8 bg-teal-200">
     <div class="container">
         <div class="row">
@@ -46,17 +59,6 @@ layout: default
         </div>
     </div>
 </div>
-
-<section class="py-5 bg-gray-900">
-    <div class="container">
-        <div class="row">
-            <div class="col-12 col-md-12 text-center text-md-start">
-                <p class="text-white">NOTE: This dashboard is a work in progress and this is not the final form it will take. There are some parts of the dashboard that are not fully functional and some data may not be accurate, so be aware that the information contained in this version should not be considered in any way definitive.</p>
-            </div>
-        </div>
-    </div>
-</section>
-
 
 {% comment %}
 <div class="py-5">


### PR DESCRIPTION
Fixes: https://github.com/mysociety/stop-and-search/issues/11

I created two version of this issue:

### Version 1
This is how it looks on a XL screen
<img width="1913" alt="Screenshot 2023-08-10 at 08 17 47" src="https://github.com/mysociety/stop-and-search/assets/13790153/5e8cacb2-f60a-4021-8a04-bfff608da74f">
This is how the page would look initially on a normal screen size. As you can see the user would have to scroll down to notice this note. Which I don't think it would be ideal.
<img width="1428" alt="Screenshot 2023-08-10 at 08 18 06" src="https://github.com/mysociety/stop-and-search/assets/13790153/e7c362c0-4502-439a-8ff6-95183fcf16ef">


### Version 2
Because of version 1 is not really noticeable unless you scroll I'm thinking version 2 would be more appropriate.
<img width="1408" alt="Screenshot 2023-08-10 at 08 20 02" src="https://github.com/mysociety/stop-and-search/assets/13790153/d8d58ac3-daed-4591-9e21-e7f6b40834f1">
The cons with this version is that it uses more space at the beginning, especially on mobile(which most likely it wouldn't be a problem because the message won't be there once we officially launch).

Let me know which one you prefer and I drop the commit that we don't want. My preferred is number 2. I think 1 is easy to miss.

