### PR TITLE
Tweak navigation language

### DIFF
--- a/area.html
+++ b/area.html
@@ -36,7 +36,7 @@ slug: area
                 <div class="d-flex align-items-end justify-content-end bg-white border-bottom border-primary border-2">
                     <a href="#stats-section" type="button" class="btn btn-primary btn-sm py-2 px-3 rounded-0 d-flex flex-column flex-sm-row align-items-center" aria-pressed="true">
                         {% include icons/stats.html width="1.5em" height="1.5em" classes="me-1 flex-grow-0 flex-shrink-0" %}
-                        <span>Stats by ethnicities</span>
+                        <span>Stats by ethnicity</span>
                     </a>
                     <a href="#local-government-section" type="button" class="btn btn-primary btn-sm py-2 px-3 rounded-0 d-flex flex-column flex-sm-row align-items-center">
                         {% include icons/people.html width="1.5em" height="1.5em" classes="me-1 flex-grow-0 flex-shrink-0" %}


### PR DESCRIPTION
The header we use is "Stop Rates by ethnicity", so use "ethnicity" rather than "ethnicities" to match.